### PR TITLE
Update test badge link and remove obsolete file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/breviam/mpesa-sdk.svg?style=flat-square)](https://packagist.org/packages/breviam/mpesa-sdk)
 [![Total Downloads](https://img.shields.io/packagist/dt/breviam/mpesa-sdk.svg?style=flat-square)](https://packagist.org/packages/breviam/mpesa-sdk)
-[![Tests](https://img.shields.io/github/workflow/status/breviam/mpesa-sdk/run-tests?label=tests)](https://github.com/Breviam-LLP/MpesaSDK/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/Breviam-LLP/MpesaSDK/ci.yml?label=tests)](https://github.com/Breviam-LLP/MpesaSDK/actions/workflows/ci.yml)
 
 A comprehensive Laravel SDK for integrating with Safaricom's M-Pesa Daraja API. This package provides a clean, well-documented interface for all major M-Pesa services including STK Push, C2B, B2C, Transaction Status, and Account Balance.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/breviam/mpesa-sdk.svg?style=flat-square)](https://packagist.org/packages/breviam/mpesa-sdk)
 [![Total Downloads](https://img.shields.io/packagist/dt/breviam/mpesa-sdk.svg?style=flat-square)](https://packagist.org/packages/breviam/mpesa-sdk)
-[![Tests](https://img.shields.io/github/workflow/status/breviam/mpesa-sdk/run-tests?label=tests)](https://github.com/breviam/mpesa-sdk/actions/workflows/run-tests.yml)
+[![Tests](https://img.shields.io/github/workflow/status/breviam/mpesa-sdk/run-tests?label=tests)](https://github.com/Breviam-LLP/MpesaSDK/actions/workflows/ci.yml)
 
 A comprehensive Laravel SDK for integrating with Safaricom's M-Pesa Daraja API. This package provides a clean, well-documented interface for all major M-Pesa services including STK Push, C2B, B2C, Transaction Status, and Account Balance.
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1efea831b82e848b24d5b45bdcc4c5aa",
+    "content-hash": "6ce9def6c9771433c92b650107381a74",
     "packages": [
         {
             "name": "brick/math",
@@ -1271,16 +1271,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.5",
+            "version": "v0.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "57b8f7efe40333cdb925700891c7d7465325d3b1"
+                "reference": "86a8b692e8661d0fb308cec64f3d176821323077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/57b8f7efe40333cdb925700891c7d7465325d3b1",
-                "reference": "57b8f7efe40333cdb925700891c7d7465325d3b1",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/86a8b692e8661d0fb308cec64f3d176821323077",
+                "reference": "86a8b692e8661d0fb308cec64f3d176821323077",
                 "shasum": ""
             },
             "require": {
@@ -1324,9 +1324,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.5"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.6"
             },
-            "time": "2025-02-11T13:34:40+00:00"
+            "time": "2025-07-07T14:17:42+00:00"
         },
         {
             "name": "laravel/serializable-closure",


### PR DESCRIPTION
Update the test badge link in the README to point to the correct GitHub Actions workflow and remove the obsolete `test_version.php` file.